### PR TITLE
Read manifest for smallest file number in case of the smallest file is missing

### DIFF
--- a/cloud/eloq_purger.cc
+++ b/cloud/eloq_purger.cc
@@ -104,7 +104,8 @@ Status S3FileNumberReader::ReadSmallestFileNumber(uint64_t *file_number) {
       }
       *file_number = manifest_max_file_number;
       Log(InfoLogLevel::INFO_LEVEL, cfs_->info_log_,
-          "Using max file number from MANIFEST as smallest file number: %llu, "
+          "Using max file number - 1 from MANIFEST as smallest file number: "
+          "%llu, "
           "object_key: %s",
           static_cast<unsigned long long>(*file_number), object_key.c_str());
       return Status::OK();


### PR DESCRIPTION
When snapshots or branches are created, the corresponding smallest_file_number_${epoch} won't exist, so we need to get the smallest file number from Manifest-${epoch} file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when recovering snapshots/branches by adding an additional fallback that can determine file range from stored metadata, reducing failures when certain remote objects are missing and improving stability in edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->