### PR TITLE
cloud: publish file number guard for rolled branches

### DIFF
--- a/cloud/cloud_file_system_impl.cc
+++ b/cloud/cloud_file_system_impl.cc
@@ -9,6 +9,7 @@
 #include "cloud/cloud_log_controller_impl.h"
 #include "cloud/cloud_manifest.h"
 #include "cloud/cloud_scheduler.h"
+#include "cloud/file_number_guard.h"
 #include "cloud/filename.h"
 #include "cloud/manifest_reader.h"
 #include "file/file_util.h"
@@ -2142,6 +2143,10 @@ IOStatus CloudFileSystemImpl::RollNewCookie(
     // crashed in the middle, we'll endup with a CLOUDMANIFEST file pointing to
     // MANIFEST file which doesn't exist in s3
     st = UploadManifest(local_dbname, delta.epoch);
+    if (!st.ok()) {
+      return st;
+    }
+    st = PutSmallestFileNumberObject(this, delta.file_num, delta.epoch);
     if (!st.ok()) {
       return st;
     }

--- a/cloud/file_number_guard.h
+++ b/cloud/file_number_guard.h
@@ -36,6 +36,7 @@
 #include <vector>
 
 #include "rocksdb/listener.h"
+#include "rocksdb/io_status.h"
 #include "rocksdb/status.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -60,6 +61,11 @@ inline constexpr char kSmallestFileNumberFilePrefix[] =
 // flight".
 std::string SmallestFileNumberObjectKey(const std::string &object_path,
                                         const std::string &epoch);
+
+// Publish a guard value for an explicit epoch. RollNewBranch uses this before
+// making the new epoch reachable through its CLOUDMANIFEST.
+IOStatus PutSmallestFileNumberObject(CloudFileSystemImpl *cfs, uint64_t value,
+                                     const std::string &epoch);
 
 // Tracks the file-number snapshots of in-flight flush/compaction jobs, keyed
 // by (thread_id, job_id). A completed job's entry lingers for entry_duration


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cloud file-system metadata handling when starting a new epoch.
  * Ensured the smallest file number is published before the cloud manifest is uploaded, helping maintain consistent file tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->