### PR TITLE
cloud: fix build error — make PutSmallestFileNumberObject take a const CloudFileSystemImpl*

### DIFF
--- a/cloud/file_number_guard.cc
+++ b/cloud/file_number_guard.cc
@@ -57,7 +57,8 @@ std::string SmallestFileNumberObjectKey(const std::string &object_path,
 // CloudFileSystemImpl::BlockPurger when no publisher is registered. Callers
 // that care about PUT ordering must serialize calls themselves (the
 // publisher's publish_mutex_ does this).
-IOStatus PutSmallestFileNumberObject(CloudFileSystemImpl *cfs, uint64_t value,
+IOStatus PutSmallestFileNumberObject(const CloudFileSystemImpl *cfs,
+                                     uint64_t value,
                                      const std::string &epoch) {
   if (epoch.empty()) {
     // Publishing to "smallest_new_file_number-" (empty epoch) would create a

--- a/cloud/file_number_guard.h
+++ b/cloud/file_number_guard.h
@@ -64,8 +64,8 @@ std::string SmallestFileNumberObjectKey(const std::string &object_path,
 
 // Publish a guard value for an explicit epoch. RollNewBranch uses this before
 // making the new epoch reachable through its CLOUDMANIFEST.
-IOStatus PutSmallestFileNumberObject(CloudFileSystemImpl *cfs, uint64_t value,
-                                     const std::string &epoch);
+IOStatus PutSmallestFileNumberObject(const CloudFileSystemImpl *cfs,
+                                     uint64_t value, const std::string &epoch);
 
 // Tracks the file-number snapshots of in-flight flush/compaction jobs, keyed
 // by (thread_id, job_id). A completed job's entry lingers for entry_duration


### PR DESCRIPTION
## Summary

Fixes a compile error introduced by the interaction of #20's `RollNewCookie` call site with the `PutSmallestFileNumberObject` signature:

```
cloud/cloud_file_system_impl.cc:2149:38: error: invalid conversion from
'const rocksdb::CloudFileSystemImpl*' to 'rocksdb::CloudFileSystemImpl*' [-fpermissive]
 2149 |     st = PutSmallestFileNumberObject(this, delta.file_num, delta.epoch);
```

`RollNewCookie` is a `const` member function, so `this` is a `const CloudFileSystemImpl*`.

## Fix

`PutSmallestFileNumberObject` only reads from the file system object — `info_log_` (a `mutable` member), `GetDestObjectPath()`, `GetDestBucketName()`, and `GetStorageProvider()` are all `const` — so the parameter is changed to `const CloudFileSystemImpl*` in both the declaration and the definition. Existing non-const callers (`FileNumberGuardPublisher::PutValue`, `CloudFileSystemImpl::BlockPurger`) convert implicitly.

## Verification

`make cloud/cloud_file_system_impl.o cloud/file_number_guard.o` now compiles both objects cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved API const-correctness for file-number tracking without changing behavior.
  * Existing values, epochs, and return behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->